### PR TITLE
Organize project framework and add MIT headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,62 @@
+<!--
+MIT License
+
+Copyright (c) 2024 promptLib contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+
 # promptLib
-A library of GPT and other LLM prompting features that can be included as a reference source.
+
+promptLib is a collection of JSON documents that hold reusable methods,
+functions, variables, and pseudocode for large-language-model prompts.  The
+library is intended to be fetched by URL and incorporated into prompt tooling
+to streamline prompt engineering workflows.
+
+## Disclaimer
+This repository includes AI-generated material which may not have been vetted
+for safety, security, or fitness for any particular purpose.  THE SOFTWARE IS
+PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR
+PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+## Intellectual Property Claims
+If you believe your intellectual property appears here without proper
+attribution or permission, please open a GitHub issue titled `IP-CLAIM:`
+followed by a short description.  Issues prefixed with `IP-CLAIM:` allow
+automated agents to filter and report claims to the maintainers.
+
+## Version History
+- **0.2.0** – Restructured repository into `data/` and `library/` directories and
+  added initial JSON frameworks. *breaking_changes*: file locations and
+  module names were reorganized.
+- **0.1.0** – Initial dataset and project scaffolding.
+
+## Acknowledgments
+Special thanks to [OpenAI](https://openai.com/api) for providing the
+platform that powers this project.
+
+## Learning Resources
+- [OpenAI Prompt Engineering Guide](https://platform.openai.com/docs/guides/prompt-engineering)
+- [DeepLearning.AI: ChatGPT Prompt Engineering for Developers](https://www.deeplearning.ai/short-courses/chatgpt-prompt-engineering-for-developers/)
+- [Stanford CRFM: Center for Research on Foundation Models](https://crfm.stanford.edu/)
+- [UK Government: A Guide to Using AI Responsibly](https://www.gov.uk/guidance/using-artificial-intelligence-in-your-business)

--- a/data/academic_repos.json
+++ b/data/academic_repos.json
@@ -1,4 +1,9 @@
 {
+  "meta": {
+    "license": "MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
+    "copyright": "Copyright (c) 2024 promptLib contributors"
+  },
   "Open Source Chat and Agent Frameworks": [
     {
       "name": "Rasa",

--- a/library/functions.json
+++ b/library/functions.json
@@ -1,0 +1,30 @@
+{
+  "meta": {
+    "license": "MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
+    "copyright": "Copyright (c) 2024 promptLib contributors",
+    "description": "Reusable helper functions for language model prompts."
+  },
+  "functions": [
+    {
+      "name": "generate_outline",
+      "description": "Create a bullet-point outline for a given topic.",
+      "parameters": {"topic": "string"},
+      "pseudocode": [
+        "def generate_outline(topic):",
+        "    # list key points about topic",
+        "    return outline"
+      ]
+    },
+    {
+      "name": "summarize_text",
+      "description": "Summarize text into a set number of sentences.",
+      "parameters": {"text": "string", "sentences": "int"},
+      "pseudocode": [
+        "def summarize_text(text, sentences):",
+        "    # compress text into the requested number of sentences",
+        "    return summary"
+      ]
+    }
+  ]
+}

--- a/library/methods.json
+++ b/library/methods.json
@@ -1,0 +1,25 @@
+{
+  "meta": {
+    "license": "MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
+    "copyright": "Copyright (c) 2024 promptLib contributors",
+    "description": "Prompting methods and strategies."
+  },
+  "methods": [
+    {
+      "name": "chain_of_thought",
+      "description": "Encourages the model to reason through problems step by step.",
+      "template": "Let's think step by step."
+    },
+    {
+      "name": "decompose_problem",
+      "description": "Break a complex task into manageable sub-tasks.",
+      "steps": [
+        "Identify the overall goal",
+        "List required subgoals",
+        "Solve each subgoal",
+        "Combine the results"
+      ]
+    }
+  ]
+}

--- a/library/pseudocode.json
+++ b/library/pseudocode.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "license": "MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
+    "copyright": "Copyright (c) 2024 promptLib contributors",
+    "description": "Small pseudocode snippets for common tasks."
+  },
+  "snippets": [
+    {
+      "name": "iterate_with_index",
+      "description": "Loop over items while tracking their index.",
+      "code": [
+        "for i, item in enumerate(items):",
+        "    # process item"
+      ]
+    },
+    {
+      "name": "read_file",
+      "description": "Read a text file and return its contents.",
+      "code": [
+        "def read_file(path):",
+        "    with open(path) as f:",
+        "        return f.read()"
+      ]
+    }
+  ]
+}

--- a/library/variables.json
+++ b/library/variables.json
@@ -1,0 +1,12 @@
+{
+  "meta": {
+    "license": "MIT",
+    "license_url": "https://opensource.org/licenses/MIT",
+    "copyright": "Copyright (c) 2024 promptLib contributors",
+    "description": "Common variables and placeholders for prompt templates."
+  },
+  "variables": [
+    {"name": "USER_NAME", "default": "User", "description": "Placeholder for the end user's name."},
+    {"name": "TASK_DESCRIPTION", "default": "", "description": "Description of the current task to perform."}
+  ]
+}


### PR DESCRIPTION
## Summary
- restructure repository into `data/` and `library/` directories to host JSON resources for prompts
- add reusable JSON modules for functions, variables, methods, and pseudocode with MIT license metadata
- rewrite README with licensing, IP-claim instructions, version history, and learning resources

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f78ff115c8328af783bbe4c40aec9